### PR TITLE
Some more logic and convinience for BTT SKR Pro boards 

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -238,14 +238,14 @@
 #define TEMP_BED_PIN                        PF3   // T0 <-> Bed
 
 // define TEMP_CHAMBER_PIN and TEMP_PROBE_PIN if needed and possible 
-#if (HOTENDS == 2)                                                             
+#if HOTENDS == 2
   #if TEMP_SENSOR_PROBE
     #define TEMP_PROBE_PIN            TEMP_2_PIN
   #elif TEMP_SENSOR_CHAMBER
     #define TEMP_CHAMBER_PIN          TEMP_2_PIN  // use T3 for Chamber sensor
   #endif
 #endif
-#if (HOTENDS << 2)                                                             
+#if HOTENDS < 2
   #if TEMP_SENSOR_PROBE
     #define TEMP_PROBE_PIN            TEMP_1_PIN  // use T2 for Probe
   #endif
@@ -256,55 +256,54 @@
 
 // change Pins to Pins without pullup, if a Sensor that doesnt need pullup is selected
 // select ADC pins without pullup, if Sensor Type needs input without pullup
-#if (TEMP_SENSOR_0 == -4) || (TEMP_SENSOR_0 == 20)
+#if TEMP_SENSOR_0 == -4 || TEMP_SENSOR_0 == 20
   #define TEMP_0_PIN PF8
 #endif
-#if (TEMP_SENSOR_1 == -4) || (TEMP_SENSOR_1 == 20)
+#if TEMP_SENSOR_1 == -4 || TEMP_SENSOR_1 == 20
   #define TEMP_1_PIN PF9
 #endif
-#if (TEMP_SENSOR_2 == -4) || (TEMP_SENSOR_2 == 20)
+#if TEMP_SENSOR_2 == -4 || TEMP_SENSOR_2 == 20
   #define TEMP_0_PIN PF10
 #endif
-#if (TEMP_SENSOR_BED == -4) || (TEMP_SENSOR_BED == 20)
+#if TEMP_SENSOR_BED == -4 || TEMP_SENSOR_BED == 20
   #define TEMP_BED_PIN PF7
 #endif
-#if (((TEMP_SENSOR_PROBE == -4) || (TEMP_SENSOR_PROBE == 20)) && TEMP_PROBE_PIN)
-  #if (HOTENDS == 2)
+#if (TEMP_SENSOR_PROBE == -4 || TEMP_SENSOR_PROBE == 20) && TEMP_PROBE_PIN
+  #if HOTENDS == 2
     #define TEMP_PROBE_PIN PF10
-  #elif (HOTENDS << 2)
+  #elif HOTENDS < 2
     #define TEMP_PROBE_PIN PF9
   #endif
 #endif
-#if (((TEMP_SENSOR_CHAMBER == -4) || (TEMP_SENSOR_CHAMBER == 20)) && TEMP_CHAMBER_PIN)
+#if (TEMP_SENSOR_CHAMBER == -4 || TEMP_SENSOR_CHAMBER == 20) && TEMP_CHAMBER_PIN
   #define TEMP_CHAMBER_PIN PF10
 #endif
-
 
 //
 // Heaters
 //
 #define HEATER_0_PIN                        PB1   // Heater0
 #define HEATER_1_PIN                        PD14  // Heater1
-#define HEATER_2_PIN                        PB0   // Heater1
 #define HEATER_BED_PIN                      PD12  // Hotbed
-#if (TEMP_CHAMBER_PIN && HOTENDS << 3)            
-  #define HEATER_CHAMBER_PIN        HEATER_2_PIN  // use HEATER_2_PIN for HEATED_CHAMBER if not three hotends                
-  #undef HEATER_2_PIN                      
+#if TEMP_CHAMBER_PIN && HOTENDS < 3
+  #define HEATER_CHAMBER_PIN                PB0   // Heater2
+#else
+  #define HEATER_2_PIN                      PB0   // Heater2
 #endif
 
 //
 // Fans
 //
 #define FAN_PIN                             PC8   // Fan0
-//#define COOLER_FAN_PIN                      FAN_PIN   // use FAN_PIN as COOLER_FAN_PIN for Laser
+//#define COOLER_FAN_PIN                 FAN_PIN  // use FAN_PIN as COOLER_FAN_PIN for Laser
 #define FAN1_PIN                            PE5   // Fan1 
 #define FAN2_PIN                            PE6   // Fan2 (This suggested to be used as CONTROLLERFAN)
-// use first Fan for Extruder cooler
+// Use first Fan for Extruder cooler
 #ifndef E0_AUTO_FAN_PIN
   #define E0_AUTO_FAN_PIN               FAN1_PIN
 #endif
 
-// use FAN2_PIN as controller FAN if there is only one extruder
+// Use FAN2_PIN as controller FAN if there is only one extruder
 #if ENABLED(USE_CONTROLLER_FAN) && HOTENDS == 1
   #define CONTROLLER_FAN_PIN FAN2_PIN
 #endif

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -272,16 +272,20 @@
   #undef  TEMP_BED_PIN
   #define TEMP_BED_PIN PF7
 #endif
-#if (TEMP_SENSOR_PROBE == -4 || TEMP_SENSOR_PROBE == 20) && TEMP_PROBE_PIN
-  #undef  TEMP_PROBE_PIN
-  #if HOTENDS == 2
-    #define TEMP_PROBE_PIN PF10
-  #elif HOTENDS < 2
-    #define TEMP_PROBE_PIN PF9
+#ifdef TEMP_PROBE_PIN
+  #if (TEMP_SENSOR_PROBE == -4 || TEMP_SENSOR_PROBE == 20)
+    #undef  TEMP_PROBE_PIN
+    #if HOTENDS == 2
+      #define TEMP_PROBE_PIN PF10
+    #elif HOTENDS < 2
+      #define TEMP_PROBE_PIN PF9
+    #endif
   #endif
 #endif
-#if (TEMP_SENSOR_CHAMBER == -4 || TEMP_SENSOR_CHAMBER == 20) && TEMP_CHAMBER_PIN
-  #define TEMP_CHAMBER_PIN PF10
+#ifdef TEMP_CHAMBER_PIN
+  #if (TEMP_SENSOR_CHAMBER == -4 || TEMP_SENSOR_CHAMBER == 20)
+    #define TEMP_CHAMBER_PIN PF10
+  #endif
 #endif
 
 // force manual select of appropriate Pins
@@ -304,13 +308,14 @@
 #define HEATER_1_PIN                        PD14  // Heater1
 #define HEATER_2_PIN                        PB0   // Heater2
 #define HEATER_BED_PIN                      PD12  // Hotbed
-#if TEMP_CHAMBER_PIN && HOTENDS < 3
-  #define HEATER_CHAMBER_PIN                HEATER_2_PIN   // Heater2
-#else
-  #error "No free heater pin for Heated Chamber found, manually select one here"
-  //define HEATER_CHAMBER_PIN
+#ifdef TEMP_CHAMBER_PIN
+  #if HOTENDS < 3
+    #define HEATER_CHAMBER_PIN                HEATER_2_PIN   // Heater2
+  #else
+    #error "No free heater pin for Heated Chamber found, manually select one here"
+    //define HEATER_CHAMBER_PIN
+  #endif
 #endif
-
 //
 // Fans
 //

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -244,8 +244,7 @@
   #elif TEMP_SENSOR_CHAMBER
     #define TEMP_CHAMBER_PIN          TEMP_2_PIN  // use T3 for Chamber sensor
   #endif
-#endif
-#if HOTENDS < 2
+#elif HOTENDS < 2
   #if TEMP_SENSOR_PROBE
     #define TEMP_PROBE_PIN            TEMP_1_PIN  // use T2 for Probe
   #endif
@@ -260,30 +259,38 @@
   #undef  TEMP_0_PIN
   #define TEMP_0_PIN PF8
 #endif
+
 #if TEMP_SENSOR_1 == -4 || TEMP_SENSOR_1 == 20
   #undef  TEMP_1_PIN
   #define TEMP_1_PIN PF9
 #endif
+
 #if TEMP_SENSOR_2 == -4 || TEMP_SENSOR_2 == 20
   #undef  TEMP_2_PIN
   #define TEMP_2_PIN PF10
 #endif
+
 #if TEMP_SENSOR_BED == -4 || TEMP_SENSOR_BED == 20
   #undef  TEMP_BED_PIN
   #define TEMP_BED_PIN PF7
 #endif
+
 #ifdef TEMP_PROBE_PIN
   #if (TEMP_SENSOR_PROBE == -4 || TEMP_SENSOR_PROBE == 20)
     #undef  TEMP_PROBE_PIN
     #if HOTENDS == 2
+      #undef  TEMP_PROBE_PIN
       #define TEMP_PROBE_PIN PF10
     #elif HOTENDS < 2
+      #undef  TEMP_PROBE_PIN
       #define TEMP_PROBE_PIN PF9
     #endif
   #endif
+
 #endif
 #ifdef TEMP_CHAMBER_PIN
   #if (TEMP_SENSOR_CHAMBER == -4 || TEMP_SENSOR_CHAMBER == 20)
+    #undef  TEMP_CHAMBER_PIN
     #define TEMP_CHAMBER_PIN PF10
   #endif
 #endif

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -329,11 +329,13 @@
 #endif
 
 // Use FAN2_PIN as controller FAN if there is only one extruder
-#if ENABLED(USE_CONTROLLER_FAN) && HOTENDS == 1
-  #define CONTROLLER_FAN_PIN FAN2_PIN
-#else
-  #error "No free Fan pin found, select a suitable pin here"
-  //#define CONTROLLER_FAN_PIN
+#if ENABLED(USE_CONTROLLER_FAN)
+  #if HOTENDS == 1
+    #define CONTROLLER_FAN_PIN FAN2_PIN
+  #else
+    #error "No free Fan pin found, select a suitable pin here"
+    //#define CONTROLLER_FAN_PIN
+  #endif
 #endif
 
 //

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -257,18 +257,23 @@
 // change Pins to Pins without pullup, if a Sensor that doesnt need pullup is selected
 // select ADC pins without pullup, if Sensor Type needs input without pullup
 #if TEMP_SENSOR_0 == -4 || TEMP_SENSOR_0 == 20
+  #undef  TEMP_0_PIN
   #define TEMP_0_PIN PF8
 #endif
 #if TEMP_SENSOR_1 == -4 || TEMP_SENSOR_1 == 20
+  #undef  TEMP_1_PIN
   #define TEMP_1_PIN PF9
 #endif
 #if TEMP_SENSOR_2 == -4 || TEMP_SENSOR_2 == 20
-  #define TEMP_0_PIN PF10
+  #undef  TEMP_2_PIN
+  #define TEMP_2_PIN PF10
 #endif
 #if TEMP_SENSOR_BED == -4 || TEMP_SENSOR_BED == 20
+  #undef  TEMP_BED_PIN
   #define TEMP_BED_PIN PF7
 #endif
 #if (TEMP_SENSOR_PROBE == -4 || TEMP_SENSOR_PROBE == 20) && TEMP_PROBE_PIN
+  #undef  TEMP_PROBE_PIN
   #if HOTENDS == 2
     #define TEMP_PROBE_PIN PF10
   #elif HOTENDS < 2
@@ -279,16 +284,31 @@
   #define TEMP_CHAMBER_PIN PF10
 #endif
 
+// force manual select of appropriate Pins
+#if HOTENDS > 2 && (TEMP_SENSOR_CHAMBER || TEMP_SENSOR_PROBE)
+  #error "Automatic selection of TEMP_PIN for CHAMBER and/or SENSOR not possible. Manually select appropriate ADC PINs here"
+  //#undef  TEMP_PROBE_PIN
+  //#define TEMP_PROBE_PIN
+  //#undef  TEMP_CHAMBER_PIN
+  //#define TEMP_CHAMBER_PIN
+#elif HOTENDS == 2 && TEMP_SENSOR_CHAMBER && TEMP_SENSOR_PROBE
+  #error "Automatic selection of TEMP_PIN for CHAMBER not possible. Manually slect a appropriate ADC PIN here"
+  //#undef  TEMP_CHAMBER_PIN
+  //#define TEMP_CHAMBER_PIN
+#endif
+
 //
 // Heaters
 //
 #define HEATER_0_PIN                        PB1   // Heater0
 #define HEATER_1_PIN                        PD14  // Heater1
+#define HEATER_2_PIN                        PB0   // Heater2
 #define HEATER_BED_PIN                      PD12  // Hotbed
 #if TEMP_CHAMBER_PIN && HOTENDS < 3
-  #define HEATER_CHAMBER_PIN                PB0   // Heater2
+  #define HEATER_CHAMBER_PIN                HEATER_2_PIN   // Heater2
 #else
-  #define HEATER_2_PIN                      PB0   // Heater2
+  #error "No free heater pin for Heated Chamber found, manually select one here"
+  //define HEATER_CHAMBER_PIN
 #endif
 
 //
@@ -306,6 +326,9 @@
 // Use FAN2_PIN as controller FAN if there is only one extruder
 #if ENABLED(USE_CONTROLLER_FAN) && HOTENDS == 1
   #define CONTROLLER_FAN_PIN FAN2_PIN
+#else
+  #error "No free Fan pin found, select a suitable pin here"
+  //#define CONTROLLER_FAN_PIN
 #endif
 
 //

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -163,31 +163,11 @@
   #define E1_CS_PIN                         PG15
 #endif
 
-// use E1 as second Y Driver 
-#ifdef Y_DUAL_STEPPER_DRIVERS
-  #define Y2_STEP_PIN                         PD15
-  #define Y2_DIR_PIN                          PE7
-  #define Y2_ENABLE_PIN                       PA3
-  #ifndef Y2_CS_PIN
-    #define Y2_CS_PIN                         PG15
-  #endif
-#endif
-
 #define E2_STEP_PIN                         PD13
 #define E2_DIR_PIN                          PG9
 #define E2_ENABLE_PIN                       PF0
 #ifndef E2_CS_PIN
   #define E2_CS_PIN                         PG12
-#endif
-
-// use E2 as second Z driver
-#if NUM_Z_STEPPER_DRIVERS > 1
-  #define Z2_STEP_PIN                         PD13
-  #define Z2_DIR_PIN                          PG9
-  #define Z2_ENABLE_PIN                       PF0
-  #ifndef Z2_CS_PIN
-    #define Z2_CS_PIN                         PG12
-  #endif
 #endif
 
 //

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -163,11 +163,31 @@
   #define E1_CS_PIN                         PG15
 #endif
 
+// use E1 as second Y Driver 
+#ifdef Y_DUAL_STEPPER_DRIVERS
+  #define Y2_STEP_PIN                         PD15
+  #define Y2_DIR_PIN                          PE7
+  #define Y2_ENABLE_PIN                       PA3
+  #ifndef Y2_CS_PIN
+    #define Y2_CS_PIN                         PG15
+  #endif
+#endif
+
 #define E2_STEP_PIN                         PD13
 #define E2_DIR_PIN                          PG9
 #define E2_ENABLE_PIN                       PF0
 #ifndef E2_CS_PIN
   #define E2_CS_PIN                         PG12
+#endif
+
+// use E2 as second Z driver
+#if NUM_Z_STEPPER_DRIVERS > 1
+  #define Z2_STEP_PIN                         PD13
+  #define Z2_DIR_PIN                          PG9
+  #define Z2_ENABLE_PIN                       PF0
+  #ifndef Z2_CS_PIN
+    #define Z2_CS_PIN                         PG12
+  #endif
 #endif
 
 //
@@ -237,19 +257,76 @@
 #define TEMP_2_PIN                          PF6   // T3 <-> E2
 #define TEMP_BED_PIN                        PF3   // T0 <-> Bed
 
+// define TEMP_CHAMBER_PIN and TEMP_PROBE_PIN if needed and possible 
+#if (HOTENDS == 2)                                                             
+  #if TEMP_SENSOR_PROBE
+    #define TEMP_PROBE_PIN            TEMP_2_PIN
+  #elif TEMP_SENSOR_CHAMBER
+    #define TEMP_CHAMBER_PIN          TEMP_2_PIN  // use T3 for Chamber sensor
+  #endif
+#endif
+#if (HOTENDS << 2)                                                             
+  #if TEMP_SENSOR_PROBE
+    #define TEMP_PROBE_PIN            TEMP_1_PIN  // use T2 for Probe
+  #endif
+  #if TEMP_SENSOR_CHAMBER
+    #define TEMP_CHAMBER_PIN          TEMP_2_PIN  // use T3 for Chamber sensor
+  #endif
+#endif
+
+// change Pins to Pins without pullup, if a Sensor that doesnt need pullup is selected
+// select ADC pins without pullup, if Sensor Type needs input without pullup
+#if (TEMP_SENSOR_0 == -4) || (TEMP_SENSOR_0 == 20)
+  #define TEMP_0_PIN PF8
+#endif
+#if (TEMP_SENSOR_1 == -4) || (TEMP_SENSOR_1 == 20)
+  #define TEMP_1_PIN PF9
+#endif
+#if (TEMP_SENSOR_2 == -4) || (TEMP_SENSOR_2 == 20)
+  #define TEMP_0_PIN PF10
+#endif
+#if (TEMP_SENSOR_BED == -4) || (TEMP_SENSOR_BED == 20)
+  #define TEMP_BED_PIN PF7
+#endif
+#if (((TEMP_SENSOR_PROBE == -4) || (TEMP_SENSOR_PROBE == 20)) && TEMP_PROBE_PIN)
+  #if (HOTENDS == 2)
+    #define TEMP_PROBE_PIN PF10
+  #elif (HOTENDS << 2)
+    #define TEMP_PROBE_PIN PF9
+  #endif
+#endif
+#if (((TEMP_SENSOR_CHAMBER == -4) || (TEMP_SENSOR_CHAMBER == 20)) && TEMP_CHAMBER_PIN)
+  #define TEMP_CHAMBER_PIN PF10
+#endif
+
+
 //
-// Heaters / Fans
+// Heaters
 //
 #define HEATER_0_PIN                        PB1   // Heater0
 #define HEATER_1_PIN                        PD14  // Heater1
 #define HEATER_2_PIN                        PB0   // Heater1
 #define HEATER_BED_PIN                      PD12  // Hotbed
-#define FAN_PIN                             PC8   // Fan0
-#define FAN1_PIN                            PE5   // Fan1
-#define FAN2_PIN                            PE6   // Fan2
+#if (TEMP_CHAMBER_PIN && HOTENDS << 3)            
+  #define HEATER_CHAMBER_PIN        HEATER_2_PIN  // use HEATER_2_PIN for HEATED_CHAMBER if not three hotends                
+  #undef HEATER_2_PIN                      
+#endif
 
+//
+// Fans
+//
+#define FAN_PIN                             PC8   // Fan0
+//#define COOLER_FAN_PIN                      FAN_PIN   // use FAN_PIN as COOLER_FAN_PIN for Laser
+#define FAN1_PIN                            PE5   // Fan1 
+#define FAN2_PIN                            PE6   // Fan2 (This suggested to be used as CONTROLLERFAN)
+// use first Fan for Extruder cooler
 #ifndef E0_AUTO_FAN_PIN
   #define E0_AUTO_FAN_PIN               FAN1_PIN
+#endif
+
+// use FAN2_PIN as controller FAN if there is only one extruder
+#if ENABELED(USE_CONTROLLER_FAN) && HOTENDS == 1
+  #define CONTROLLER_FAN_PIN FAN2_PIN
 #endif
 
 //

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -325,7 +325,7 @@
 #endif
 
 // use FAN2_PIN as controller FAN if there is only one extruder
-#if ENABELED(USE_CONTROLLER_FAN) && HOTENDS == 1
+#if ENABLED(USE_CONTROLLER_FAN) && HOTENDS == 1
   #define CONTROLLER_FAN_PIN FAN2_PIN
 #endif
 

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -256,55 +256,55 @@
 // change Pins to Pins without pullup, if a Sensor that doesnt need pullup is selected
 // select ADC pins without pullup, if Sensor Type needs input without pullup
 #if TEMP_SENSOR_0 == -4 || TEMP_SENSOR_0 == 20
-  #undef  TEMP_0_PIN
-  #define TEMP_0_PIN PF8
+  #undef TEMP_0_PIN
+  #define TEMP_0_PIN                        PF8
 #endif
 
 #if TEMP_SENSOR_1 == -4 || TEMP_SENSOR_1 == 20
-  #undef  TEMP_1_PIN
-  #define TEMP_1_PIN PF9
+  #undef TEMP_1_PIN
+  #define TEMP_1_PIN                        PF9
 #endif
 
 #if TEMP_SENSOR_2 == -4 || TEMP_SENSOR_2 == 20
-  #undef  TEMP_2_PIN
-  #define TEMP_2_PIN PF10
+  #undef TEMP_2_PIN
+  #define TEMP_2_PIN                        PF10
 #endif
 
 #if TEMP_SENSOR_BED == -4 || TEMP_SENSOR_BED == 20
-  #undef  TEMP_BED_PIN
-  #define TEMP_BED_PIN PF7
+  #undef TEMP_BED_PIN
+  #define TEMP_BED_PIN                      PF7
 #endif
 
 #ifdef TEMP_PROBE_PIN
   #if (TEMP_SENSOR_PROBE == -4 || TEMP_SENSOR_PROBE == 20)
-    #undef  TEMP_PROBE_PIN
+    #undef TEMP_PROBE_PIN
     #if HOTENDS == 2
-      #undef  TEMP_PROBE_PIN
-      #define TEMP_PROBE_PIN PF10
+      #undef TEMP_PROBE_PIN
+      #define TEMP_PROBE_PIN                PF10
     #elif HOTENDS < 2
-      #undef  TEMP_PROBE_PIN
-      #define TEMP_PROBE_PIN PF9
+      #undef TEMP_PROBE_PIN
+      #define TEMP_PROBE_PIN                PF9
     #endif
   #endif
 
 #endif
 #ifdef TEMP_CHAMBER_PIN
   #if (TEMP_SENSOR_CHAMBER == -4 || TEMP_SENSOR_CHAMBER == 20)
-    #undef  TEMP_CHAMBER_PIN
-    #define TEMP_CHAMBER_PIN PF10
+    #undef TEMP_CHAMBER_PIN
+    #define TEMP_CHAMBER_PIN                PF10
   #endif
 #endif
 
 // force manual select of appropriate Pins
 #if HOTENDS > 2 && (TEMP_SENSOR_CHAMBER || TEMP_SENSOR_PROBE)
   #error "Automatic selection of TEMP_PIN for CHAMBER and/or SENSOR not possible. Manually select appropriate ADC PINs here"
-  //#undef  TEMP_PROBE_PIN
+  //#undef TEMP_PROBE_PIN
   //#define TEMP_PROBE_PIN
-  //#undef  TEMP_CHAMBER_PIN
+  //#undef TEMP_CHAMBER_PIN
   //#define TEMP_CHAMBER_PIN
 #elif HOTENDS == 2 && TEMP_SENSOR_CHAMBER && TEMP_SENSOR_PROBE
   #error "Automatic selection of TEMP_PIN for CHAMBER not possible. Manually slect a appropriate ADC PIN here"
-  //#undef  TEMP_CHAMBER_PIN
+  //#undef TEMP_CHAMBER_PIN
   //#define TEMP_CHAMBER_PIN
 #endif
 
@@ -317,7 +317,7 @@
 #define HEATER_BED_PIN                      PD12  // Hotbed
 #ifdef TEMP_CHAMBER_PIN
   #if HOTENDS < 3
-    #define HEATER_CHAMBER_PIN                HEATER_2_PIN   // Heater2
+    #define HEATER_CHAMBER_PIN      HEATER_2_PIN  // Heater2
   #else
     #error "No free heater pin for Heated Chamber found, manually select one here"
     //define HEATER_CHAMBER_PIN
@@ -338,7 +338,7 @@
 // Use FAN2_PIN as controller FAN if there is only one extruder
 #if ENABLED(USE_CONTROLLER_FAN)
   #if HOTENDS == 1
-    #define CONTROLLER_FAN_PIN FAN2_PIN
+    #define CONTROLLER_FAN_PIN          FAN2_PIN
   #else
     #error "No free Fan pin found, select a suitable pin here"
     //#define CONTROLLER_FAN_PIN


### PR DESCRIPTION
### Requirements

The BTT SKR Pro Board opens a lot of options for the user. Unlike for other BTT boards the pin header is file is very "simple"

### Description

This pull requests adds some more logic to the file to automatically assign pins if user enables options:
Y_DUAL_STPPER_DRIVERS
NUM_Z_STEPPER_DRIVERS > 1
TEMP_SENSOR_PROBE
TEMP_SENSOR_CHAMBER
USE_CONTROLLER_FAN
It tries to identify unused pins for those options and assigns them if possible without need for the user to modify this file

Furthermore if Sensortypes -4 or 20 (which do not need a pullup resistor / are incompatible with pullup Resistors) are selected for a specific sensor the pin gets reasigned to pullup free ADC Pins of Extension1.

### Benefits

Reduces the need to modify this file if named options are activated. More nice options can be added.

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
