### PR TITLE
Fix PlatformIO deprecation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ __pycache__
 
 # IOLogger logs
 *_log.csv
+
+#IntelliJ
+*.iml

--- a/ini/avr.ini
+++ b/ini/avr.ini
@@ -16,7 +16,7 @@
 platform          = atmelavr@~3.4
 build_flags       = ${common.build_flags} -Wl,--relax
 board_build.f_cpu = 16000000L
-src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
+build_src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
 
 #
 # ATmega2560

--- a/ini/due.ini
+++ b/ini/due.ini
@@ -18,7 +18,7 @@
 [env:DUE]
 platform   = atmelsam
 board      = due
-src_filter = ${common.default_src_filter} +<src/HAL/DUE> +<src/HAL/shared/backtrace>
+build_src_filter = ${common.default_src_filter} +<src/HAL/DUE> +<src/HAL/shared/backtrace>
 
 [env:DUE_USB]
 extends  = env:DUE

--- a/ini/esp32.ini
+++ b/ini/esp32.ini
@@ -16,7 +16,7 @@
 platform      = espressif32@2.1.0
 board         = esp32dev
 build_flags   = ${common.build_flags} -DCORE_DEBUG_LEVEL=0
-src_filter    = ${common.default_src_filter} +<src/HAL/ESP32>
+build_src_filter    = ${common.default_src_filter} +<src/HAL/ESP32>
 lib_ignore    = NativeEthernet
 upload_speed  = 500000
 monitor_speed = 250000

--- a/ini/lpc176x.ini
+++ b/ini/lpc176x.ini
@@ -20,7 +20,7 @@ lib_ldf_mode      = off
 lib_compat_mode   = strict
 extra_scripts     = ${common.extra_scripts}
   Marlin/src/HAL/LPC1768/upload_extra_script.py
-src_filter        = ${common.default_src_filter} +<src/HAL/LPC1768> +<src/HAL/shared/backtrace>
+build_src_filter        = ${common.default_src_filter} +<src/HAL/LPC1768> +<src/HAL/shared/backtrace>
 lib_deps          = ${common.lib_deps}
   Servo
 custom_marlin.USES_LIQUIDCRYSTAL =  arduino-libraries/LiquidCrystal@~1.0.7

--- a/ini/native.ini
+++ b/ini/native.ini
@@ -16,11 +16,11 @@
 platform        = native
 framework       =
 build_flags     = -D__PLAT_LINUX__ -std=gnu++17 -ggdb -g -lrt -lpthread -D__MARLIN_FIRMWARE__ -Wno-expansion-to-defined
-src_build_flags = -Wall -IMarlin/src/HAL/LINUX/include
+build_src_flags = -Wall -IMarlin/src/HAL/LINUX/include
 build_unflags   = -Wall
 lib_ldf_mode    = off
 lib_deps        =
-src_filter      = ${common.default_src_filter} +<src/HAL/LINUX>
+build_src_filter      = ${common.default_src_filter} +<src/HAL/LINUX>
 
 #
 # Native Simulation
@@ -39,7 +39,7 @@ src_build_flags   = -Wall -Wno-expansion-to-defined -Wcast-align
 release_flags     = -g0 -O3 -flto
 debug_build_flags = -fstack-protector-strong -g -g3 -ggdb
 lib_compat_mode   = off
-src_filter        = ${common.default_src_filter} +<src/HAL/NATIVE_SIM>
+build_src_filter  = ${common.default_src_filter} +<src/HAL/NATIVE_SIM>
 lib_deps          = ${common.lib_deps}
   MarlinSimUI=https://github.com/p3p/MarlinSimUI/archive/0.0.2.zip
   Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/marlin_sim_native.zip
@@ -107,6 +107,6 @@ build_unflags   = ${simulator_macos.build_unflags}
 #
 [env:simulator_windows]
 extends     = simulator_common
-src_build_flags = ${simulator_common.src_build_flags} -fpermissive
+build_src_flags = ${simulator_common.src_build_flags} -fpermissive
 build_flags = ${simulator_common.build_flags} ${simulator_common.debug_build_flags} -IC:\\msys64\\mingw64\\include\\SDL2 -fno-stack-protector -Wl,-subsystem,windows -ldl -lmingw32 -lSDL2main -lSDL2 -lSDL2_net -lopengl32 -lssp
 build_type = debug

--- a/ini/samd51.ini
+++ b/ini/samd51.ini
@@ -17,7 +17,7 @@ platform       = atmelsam
 board          = adafruit_grandcentral_m4
 build_flags    = ${common.build_flags} -std=gnu++17
 build_unflags  = -std=gnu++11
-src_filter     = ${common.default_src_filter} +<src/HAL/SAMD51>
+build_src_filter     = ${common.default_src_filter} +<src/HAL/SAMD51>
 lib_deps       = ${common.lib_deps}
   SoftwareSerialM
 extra_scripts  = ${common.extra_scripts}

--- a/ini/stm32-common.ini
+++ b/ini/stm32-common.ini
@@ -17,7 +17,7 @@ build_flags      = ${common.build_flags}
                    -DUSBCON -DUSBD_USE_CDC
                    -DTIM_IRQ_PRIO=13
 build_unflags    = -std=gnu++11
-src_filter       = ${common.default_src_filter} +<src/HAL/STM32> +<src/HAL/shared/backtrace>
+build_src_filter = ${common.default_src_filter} +<src/HAL/STM32> +<src/HAL/shared/backtrace>
 extra_scripts    = ${common.extra_scripts}
                    pre:buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
 

--- a/ini/stm32f0.ini
+++ b/ini/stm32f0.ini
@@ -48,4 +48,4 @@ board       = malyanm300_f070cb
 build_flags = ${common_stm32.build_flags}
               -DHAL_PCD_MODULE_ENABLED -DDISABLE_GENERIC_SERIALUSB
               -DHAL_UART_MODULE_ENABLED
-src_filter  = ${common.default_src_filter} +<src/HAL/STM32>
+build_src_filter  = ${common.default_src_filter} +<src/HAL/STM32>

--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -28,7 +28,7 @@ board_build.core  = maple
 build_flags       = !python Marlin/src/HAL/STM32F1/build_flags.py
   ${common.build_flags} -DARDUINO_ARCH_STM32 -DMAPLE_STM32F1
 build_unflags     = -std=gnu11 -std=gnu++11
-src_filter        = ${common.default_src_filter} +<src/HAL/STM32F1>
+build_src_filter        = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_ignore        = SPI, FreeRTOS701, FreeRTOS821
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -238,7 +238,7 @@ board       = malyanm200_f103cb
 build_flags = ${common_stm32.build_flags}
               -DHAL_PCD_MODULE_ENABLED -DDISABLE_GENERIC_SERIALUSB
               -DHAL_UART_MODULE_ENABLED
-src_filter  = ${common.default_src_filter} +<src/HAL/STM32>
+build_src_filter  = ${common.default_src_filter} +<src/HAL/STM32>
 
 #
 # FLYmaker FLY Mini (STM32F103RCT6)

--- a/ini/stm32g0.ini
+++ b/ini/stm32g0.ini
@@ -23,17 +23,17 @@
 # BigTree SKR mini E3 V3.0 (STM32G0B1RET6 ARM Cortex-M0+)
 #
 [env:STM32G0B1RE_btt]
-extends                     = stm32_variant
-platform                    = ststm32@~14.1.0
-platform_packages           = framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/main.zip
-board                       = marlin_STM32G0B1RE
+platform          = ststm32@~14.1.0
+platform_packages = framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/main.zip
+extends            = stm32_variant
+board              = marlin_STM32G0B1RE
 board_build.offset          = 0x2000
 board_upload.offset_address = 0x08002000
-build_flags                 = ${stm32_variant.build_flags}
-                            -DADC_RESOLUTION=12
-                            -DPIN_SERIAL4_RX=PC_11 -DPIN_SERIAL4_TX=PC_10
-                            -DSERIAL_RX_BUFFER_SIZE=1024 -DSERIAL_TX_BUFFER_SIZE=1024
-                            -DTIMER_SERVO=TIM3 -DTIMER_TONE=TIM4
-                            -DSTEP_TIMER_IRQ_PRIO=0
-upload_protocol             = stlink
-debug_tool                  = stlink
+build_flags        = ${stm32_variant.build_flags}
+                   -DADC_RESOLUTION=12
+                   -DPIN_SERIAL4_RX=PC_11 -DPIN_SERIAL4_TX=PC_10
+                   -DSERIAL_RX_BUFFER_SIZE=1024 -DSERIAL_TX_BUFFER_SIZE=1024
+                   -DTIMER_SERVO=TIM3 -DTIMER_TONE=TIM4
+                   -DSTEP_TIMER_IRQ_PRIO=0
+upload_protocol   = stlink
+debug_tool        = stlink

--- a/ini/teensy.ini
+++ b/ini/teensy.ini
@@ -46,7 +46,7 @@ board   = teensy2pp
 #
 [teensy_arm]
 platform   = teensy@~4.12.0
-src_filter = ${common.default_src_filter}
+build_src_filter = ${common.default_src_filter}
 lib_ignore = NativeEthernet
 
 #
@@ -55,7 +55,7 @@ lib_ignore = NativeEthernet
 [env:teensy31]
 extends    = teensy_arm
 board      = teensy31
-src_filter = ${teensy_arm.src_filter} +<src/HAL/TEENSY31_32>
+build_src_filter = ${teensy_arm.src_filter} +<src/HAL/TEENSY31_32>
 
 #
 # Teensy 3.5 / 3.6 (ARM Cortex-M4)
@@ -63,12 +63,12 @@ src_filter = ${teensy_arm.src_filter} +<src/HAL/TEENSY31_32>
 [env:teensy35]
 extends    = teensy_arm
 board      = teensy35
-src_filter = ${teensy_arm.src_filter} +<src/HAL/TEENSY35_36>
+build_src_filter = ${teensy_arm.src_filter} +<src/HAL/TEENSY35_36>
 
 [env:teensy36]
 extends    = teensy_arm
 board      = teensy36
-src_filter = ${teensy_arm.src_filter} +<src/HAL/TEENSY35_36>
+build_src_filter = ${teensy_arm.src_filter} +<src/HAL/TEENSY35_36>
 
 #
 # Teensy 4.0 / 4.1 (ARM Cortex-M7)
@@ -76,5 +76,5 @@ src_filter = ${teensy_arm.src_filter} +<src/HAL/TEENSY35_36>
 [env:teensy41]
 extends    = teensy_arm
 board      = teensy41
-src_filter = ${teensy_arm.src_filter} +<src/HAL/TEENSY40_41>
+build_src_filter = ${teensy_arm.src_filter} +<src/HAL/TEENSY40_41>
 lib_ignore =

--- a/platformio.ini
+++ b/platformio.ini
@@ -52,7 +52,7 @@ lib_deps           =
 default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/lcd/HD44780> -<src/lcd/TFTGLCD> -<src/lcd/dogm> -<src/lcd/tft> -<src/lcd/tft_io>
   -<src/HAL/STM32/tft> -<src/HAL/STM32F1/tft>
-  -<src/lcd/e3v2/common> -<src/lcd/e3v2/creality> -<src/lcd/e3v2/proui> -<src/lcd/e3v2/jyersui> -<src/lcd/e3v2/marlinui>
+  -<src/lcd/e3v2/common> -<src/lcd/e3v2/creality> -<src/lcd/e3v2/enhanced> -<src/lcd/e3v2/jyersui> -<src/lcd/e3v2/marlinui>
   -<src/lcd/menu>
   -<src/lcd/menu/game/game.cpp> -<src/lcd/menu/game/brickout.cpp> -<src/lcd/menu/game/invaders.cpp>
   -<src/lcd/menu/game/maze.cpp> -<src/lcd/menu/game/snake.cpp>
@@ -205,7 +205,6 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/gcode/feature/trinamic/M569.cpp>
   -<src/gcode/feature/trinamic/M906.cpp>
   -<src/gcode/feature/trinamic/M911-M914.cpp>
-  -<src/gcode/feature/trinamic/M919.cpp>
   -<src/gcode/geometry/G17-G19.cpp>
   -<src/gcode/geometry/G53-G59.cpp>
   -<src/gcode/geometry/M206_M428.cpp>
@@ -266,15 +265,6 @@ extra_scripts = ${common.extra_scripts}
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
 monitor_speed = 250000
-monitor_flags =
-  --quiet
-  --echo
-  --eol
-    LF
-  --filter
-    colorize
-  --filter
-    time
 
 #
 # Just print the dependency tree
@@ -283,4 +273,4 @@ monitor_flags =
 platform    = atmelavr
 board       = megaatmega2560
 build_flags = -c -H -std=gnu++11 -Wall -Os -D__MARLIN_FIRMWARE__
-src_filter  = +<src/MarlinCore.cpp>
+build_src_filter  = +<src/MarlinCore.cpp>


### PR DESCRIPTION
### Description

When I run `pio run` I was getting a bunch of deprecated issues so I updated it

### Benefits

Removes some warning messages when building

### Configurations

Used the default ones and it built
