### PR TITLE
Add Emulated EEPROM & Probe Enable Pin

### DIFF
--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M4P_V1_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M4P_V1_0.h
@@ -33,9 +33,30 @@
 //#define BOGUS_TEMPERATURE_GRACE_PERIOD    2000
 
 //
+// EEPROM
+//
+#if NO_EEPROM_SELECTED
+  #define SDCARD_EEPROM_EMULATION
+  //#define FLASH_EEPROM_EMULATION
+  //#ifndef MARLIN_EEPROM_SIZE
+  //  #define MARLIN_EEPROM_SIZE 0x800U             // 2K
+  //#endif
+  #undef NO_EEPROM_SELECTED
+#endif
+
+//
 // Servos
 //
 #define SERVO0_PIN                          PA1   // SERVOS
+
+//
+// Probe enable
+//
+#if ENABLED(PROBE_ENABLE_DISABLE)
+  #ifndef PROBE_ENABLE_PIN
+    #define PROBE_ENABLE_PIN         SERVO0_PIN
+  #endif
+#endif
 
 //
 // Limit Switches

--- a/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_V1_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_MANTA_M8P_V1_0.h
@@ -33,9 +33,30 @@
 //#define BOGUS_TEMPERATURE_GRACE_PERIOD    2000
 
 //
+// EEPROM
+//
+#if NO_EEPROM_SELECTED
+  #define SDCARD_EEPROM_EMULATION
+  //#define FLASH_EEPROM_EMULATION
+  //#ifndef MARLIN_EEPROM_SIZE
+  //  #define MARLIN_EEPROM_SIZE 0x800U             // 2K
+  //#endif
+  #undef NO_EEPROM_SELECTED
+#endif
+
+//
 // Servos
 //
 #define SERVO0_PIN                          PB1   // SERVOS
+
+//
+// Probe enable
+//
+#if ENABLED(PROBE_ENABLE_DISABLE)
+  #ifndef PROBE_ENABLE_PIN
+    #define PROBE_ENABLE_PIN         SERVO0_PIN
+  #endif
+#endif
 
 //
 // Trinamic Stallguard pins


### PR DESCRIPTION
### Description

- Add Emulated EEPROM (see Known Issues below)
- Add probe enable pin for BTT Microprobe

### Known Issues

- `FLASH_EEPROM_EMULATION` causes Manta boards to bootloop.
- `SDCARD_EEPROM_EMULATION` only works on the LCD's SD card slot since onboard SD reader doesn't seem to work at all (`#define SDCARD_CONNECTION ONBOARD`).
- Since `FLASH_EEPROM_EMULATION` doesn't work, `EEPROM_SETTINGS` & `SDCARD_CONNECTION LCD` must be enabled/set when using `BTT_MINI_12864_V1` (even if no SD card is present), to correctly set the LCD contrast. The LCD will be unreadable otherwise.
- LCD SD cannot be read when using `REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER`. I have not tested all possible LCD combinations, but that will likely be a common one.
